### PR TITLE
CLOSES #1: Fixed Guest Additions check errors seen with vagrant up.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,7 +1,7 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
-$box_version = "6.8.0"
+$box_version = "6.8.1"
 $share_home = false
 $vm_cpus = 1
 $vm_gui = false

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,21 +1,22 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
-$image_version = "6.8.0"
+$box_version = "6.8.0"
 $share_home = false
 $vm_cpus = 1
 $vm_gui = false
+$vm_hostname = "centos-6.local"
 $vm_memory = 512
 $vm_name = "centos-6"
-$vm_hostname = "centos-6.local"
 
 Vagrant.configure(2) do |config|
   config.vm.box = "jdeathe/centos-6"
-  config.vm.box_url = "https://atlas.hashicorp.com/jdeathe/boxes/centos-6/versions/%s/providers/virtualbox.box" % $image_version
+  config.vm.box_version = $box_version
+  # config.vm.box_url = "https://atlas.hashicorp.com/jdeathe/boxes/centos-6/versions/%s/providers/virtualbox.box" % $box_version
+  # config.vm.box_url = "https://github.com/jdeathe/packer-centos-6/releases/download/%s/centos-6-virtualbox.box" % $box_version
 
   config.vm.define $vm_name
   config.vm.hostname = $vm_hostname
-  config.vm.provider "virtualbox"
 
   # Disable automatic box update checking. If you disable this, then
   # boxes will only be checked for updates when the user runs
@@ -26,7 +27,6 @@ Vagrant.configure(2) do |config|
   # within the machine from a port on the host machine. In the example below,
   # accessing "localhost:8080" will access port 80 on the guest machine.
   # config.vm.network "forwarded_port", guest: 80, host: 8080
-  config.vm.network "forwarded_port", guest: 22, host: 2222, id: "ssh", auto_correct: true
 
   # Create a private network, which allows host-only access to the machine
   # using a specific IP.
@@ -37,41 +37,27 @@ Vagrant.configure(2) do |config|
   # your network.
   # config.vm.network "public_network"
 
-  # Disable the default Vagrant directory sync
-  config.vm.synced_folder ".", "/home/vagrant/sync", disabled: true
-  config.vm.synced_folder ".", "/vagrant", disabled: true
-
   # Enable NFS shared home directory
   if $share_home
-    config.vm.synced_folder ENV['HOME'], ENV['HOME'], id: "home", :nfs => true, :mount_options => ["nolock","vers=3","udp"]
+    config.vm.synced_folder \
+      ENV['HOME'], 
+      ENV['HOME'], 
+      id: "home", 
+      :nfs => true, 
+      :mount_options => ["nolock","vers=3","udp"]
   end
 
   # VirtualBox Guest customisations
   config.vm.provider "virtualbox" do |vb|
-    # Prevent checking VirtualBox GuestAdditions
-    vb.check_guest_additions = false
-
-    # Prevent checking VirtualBox Shared Folders
-    vb.functional_vboxsf = false
-
     vb.cpus = $vm_cpus
     vb.gui = $vm_gui
     vb.memory = $vm_memory
     vb.name = $vm_name
   end
 
-  # Define a Vagrant Push strategy for pushing to Atlas. Other push strategies
-  # such as FTP and Heroku are also available. See the documentation at
-  # https://docs.vagrantup.com/v2/push/atlas.html for more information.
-  # config.push.define "atlas" do |push|
-  #   push.app = "YOUR_ATLAS_USERNAME/YOUR_APPLICATION_NAME"
-  # end
-
   # Enable provisioning with a shell script. Additional provisioners such as
   # Puppet, Chef, Ansible, Salt, and Docker are also available. Please see the
   # documentation for more information about their specific syntax and use.
-  # config.vm.provision "shell", inline: <<-SHELL
-  #   sudo apt-get update
-  #   sudo apt-get install -y apache2
-  # SHELL
+  # config.vm.provision "shell", keep_color: true, name: "YUM Update", inline: "yum -y update"
+  # config.vm.provision "shell", keep_color: true, name: "Install Apache", inline: "yum -y install httpd"
 end

--- a/centos-6.json
+++ b/centos-6.json
@@ -65,6 +65,7 @@
     },
     {
       "type": "vagrant",
+      "vagrantfile_template": "centos-6.vagrantfile",
       "output": "builds/{{.BuildName}}-{{.Provider}}.box",
       "compression_level": 9,
       "keep_input_artifact": false

--- a/centos-6.vagrantfile
+++ b/centos-6.vagrantfile
@@ -1,0 +1,29 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure(2) do |config|
+
+  # Set the user for SSH access
+  config.ssh.username = "vagrant"
+
+  config.vm.network "forwarded_port", 
+    guest: 22, 
+    host: 2222, 
+    id: "ssh", 
+    auto_correct: true
+
+  # Disable the default Vagrant directory sync
+  config.vm.synced_folder ".", 
+    "/vagrant", 
+    disabled: true
+
+  # VirtualBox Guest customisations
+  config.vm.provider "virtualbox" do |vb|
+
+    # Prevent checking VirtualBox GuestAdditions
+    vb.check_guest_additions = false
+
+    # Prevent checking VirtualBox Shared Folders
+    vb.functional_vboxsf = false
+  end
+end


### PR DESCRIPTION
Resolves #1 
- Created a default Vagrantfile as part of the build process. This allows use of `vagrant init jdeathe/centos-6` to generate a Vagrantfile automatically.
- Updated the example Vagrantfile.
