### PR TITLE
CLOSES #5: Install and enable tuned and the virtual-guest profile.

### DIFF
--- a/http/centos-6-base-vagrant-virtualbox-ks.cfg
+++ b/http/centos-6-base-vagrant-virtualbox-ks.cfg
@@ -19,11 +19,12 @@ clearpart --all --initlabel
 # part swap --grow --size=1024
 autopart
 user --name=vagrant --groups=wheel --password=vagrant
-services --enabled ntpd
+services --enabled ntpd, tuned
 reboot
 
 %packages --instLangs=en_GB.UTF-8 --nobase --nocore --ignoremissing --excludedocs
 @core --nodefaults
+tuned
 
 # Core Mandatory Packages to exclude
 # -cronie
@@ -79,9 +80,10 @@ reboot
 /bin/chown -R vagrant:vagrant /home/vagrant
 /bin/chmod 0600 /home/vagrant/.ssh/authorized_keys
 /sbin/dracut -f -H
+/usr/bin/tuned-adm profile virtual-guest
 /usr/bin/yum clean all
-/bin/rpm --rebuilddb
 /bin/rpm --erase --nodeps redhat-logos
+/bin/rpm --rebuilddb
 /bin/rm -rf /etc/ld.so.cache
 /bin/rm -rf /sbin/sln
 /bin/rm -rf /usr/{{lib,share}/locale,share/{man,doc,info,gnome/help,cracklib,il8n},{lib,lib64}/gconv,bin/localedef,sbin/build-locale-archive}


### PR DESCRIPTION
Resolves #5 
- https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/6/html/Power_Management_Guide/tuned-adm.html
- Configured with the `virtual-guest` profile: 

> This profile is optimized for virtual machines. It is based on the enterprise-storage profile, but also decreases the swappiness of virtual memory.
