### PR TITLE
CLOSES #6: Manually define partitions and logical volumes.

### DIFF
--- a/http/centos-6-base-vagrant-virtualbox-ks.cfg
+++ b/http/centos-6-base-vagrant-virtualbox-ks.cfg
@@ -13,11 +13,19 @@ authconfig --enableshadow --passalgo=sha512
 selinux --permissive
 zerombr
 bootloader --location=mbr --append="crashkernel=auto rhgb quiet"
+
+# Partitions
 clearpart --all --initlabel
-# part / --grow --size=40960 --fstype=ext4 --asprimary
-# part /boot --size=250 --fstype=ext4
-# part swap --grow --size=1024
-autopart
+part biosboot --size=1 --fstype=biosboot
+part /boot --size=250 --fstype=ext4
+part pv.01 --size=1 --grow
+
+# Logical Volumes
+# 32768 Physical Extents = 16MiB @ 512 bytes/sector.
+volgroup vg_root --pesize=32768 pv.01
+logvol swap --vgname=vg_root --size=768 --name=lv_swap --fstype=swap --grow --maxsize=4096 
+logvol / --vgname=vg_root --size=1024 --name=lv_root --fstype=ext4 --grow
+
 user --name=vagrant --groups=wheel --password=vagrant
 services --enabled ntpd, tuned
 reboot

--- a/http/centos-6-base-vagrant-virtualbox-ks.cfg
+++ b/http/centos-6-base-vagrant-virtualbox-ks.cfg
@@ -23,7 +23,7 @@ part pv.01 --size=1 --grow
 # Logical Volumes
 # 32768 Physical Extents = 16MiB @ 512 bytes/sector.
 volgroup vg_root --pesize=32768 pv.01
-logvol swap --vgname=vg_root --size=768 --name=lv_swap --fstype=swap --grow --maxsize=4096 
+logvol swap --vgname=vg_root --size=512 --name=lv_swap --fstype=swap --grow --maxsize=4096
 logvol / --vgname=vg_root --size=1024 --name=lv_root --fstype=ext4 --grow
 
 user --name=vagrant --groups=wheel --password=vagrant


### PR DESCRIPTION
Resolves #6 
- Create a 250M /boot partition
- Create a Volume Group `vg_root`
- Create Logical Volume `lv_swap` for swap - starting at 512M (1*default RAM allocation) and growing to 4096M (expected limit of VM RAM allocation)
- Create Logical Volume `lv_root` for the root directory and allow it to fill the rest of the available disk space ~ 38GB.
