### PR TITLE
CLOSES #9: Remove unused locales instead of removing all locale support.

### DIFF
--- a/http/centos-6-base-vagrant-virtualbox-ks.cfg
+++ b/http/centos-6-base-vagrant-virtualbox-ks.cfg
@@ -80,7 +80,13 @@ tuned
 %end
 
 %post
-/bin/sed -i -e 's~^#PermitRootLogin yes~PermitRootLogin no~g' -e 's~^#UseDNS yes~UseDNS no~g' /etc/ssh/sshd_config
+# Prevent SSH root login, prevent DNS lookup of connecting hosts (slow), 
+# Don't allow Locale environment variables - have restricted to en_GB.UTF-8
+/bin/sed -i \
+  -e 's~^#PermitRootLogin yes~PermitRootLogin no~g' \
+  -e 's~^#UseDNS yes~UseDNS no~g' \
+  -e 's~^AcceptEnv \(.*\)~#AcceptEnv \1~g' \
+  /etc/ssh/sshd_config
 /bin/echo -e '%wheel ALL=(ALL) NOPASSWD: ALL' > /etc/sudoers.d/wheel
 /bin/chmod 0440 /etc/sudoers.d/wheel
 /bin/mkdir -pm 0700 /home/vagrant/.ssh
@@ -92,11 +98,37 @@ tuned
 /usr/bin/yum clean all
 /bin/rpm --erase --nodeps redhat-logos
 /bin/rpm --rebuilddb
-/bin/rm -rf /etc/ld.so.cache
-/bin/rm -rf /sbin/sln
-/bin/rm -rf /usr/{{lib,share}/locale,share/{man,doc,info,gnome/help,cracklib,il8n},{lib,lib64}/gconv,bin/localedef,sbin/build-locale-archive}
+
+# Remove all but en_GB.utf8 and en_US.utf8 from the locale archive and rebuild.
+/usr/bin/localedef --list-archive | \
+  /bin/awk '!/^en_(GB|US).utf8$/' | \
+  /usr/bin/xargs /usr/bin/localedef --delete-from-archive
+/bin/mv /usr/lib/locale/locale-archive /usr/lib/locale/locale-archive.tmpl
+/usr/sbin/build-locale-archive
+/usr/bin/truncate -s 0 /usr/lib/locale/locale-archive.tmpl
+
+# Remove all files from subdirectories of /usr/share/locale except the contents  
+# of /usr/share/locale/en_GB or /usr/share/locale/en_@* directories.
+/bin/find /usr/share/locale -mindepth 1 -maxdepth 1 -type d | \
+  /bin/awk '!/^\/usr\/share\/locale\/en(_(GB|US)|@.*)?$/' | \
+  /usr/bin/xargs -I {} /bin/find {} -type f -delete
+
+# Delete all except UTF-8.gz from character map files
+# /bin/find /usr/share/i18n/charmaps -type f -not -name UTF-8.gz -delete
+# Remove locale files for unused languages.
+/bin/find /usr/share/i18n/locales -type f | \
+  /bin/awk '!/\/en(_(GB|US))?(.(utf|UTF-)8)?$/' | \
+  /bin/awk '/[a-z][a-z]([a-z])?_[A-Z][A-Z](@.+)?/' \
+  /usr/bin/xargs -I {} /bin/find {} -type f -delete
+
+# Uncomment to unset system locale
+# /usr/bin/truncate -s 0 /etc/sysconfig/i18n
+
+# Remove manual and documentation files but leave directory structure.
+/bin/find /usr/share/{man,doc,info,gnome/help} -type f -delete
+
+# Remove contents of temporary dictories and zero out free space on disk
 /bin/rm -rf /{root,tmp,var/cache/{ldconfig,yum}}/*
-/bin/echo '' > /etc/sysconfig/i18n
 /bin/dd if=/dev/zero of=/boot/zero.out bs=1M
 /bin/dd if=/dev/zero of=/zero.out bs=1M
 /bin/sync


### PR DESCRIPTION
Resolves #9 
- Remove unused system locales while retaining support for en, en_GB, en_US, en_GB.UTF-8 and en_US.UTF-8.
- Prevent forwarding of locale related environment variables in SSH sessions.
- Retain the system locale. i.e. `LANG="en_GB.UTF-8"`
