### PR TITLE
CLOSES #15: Remove wallpaper images instead of redhat-logos package

### DIFF
--- a/http/centos-6-base-vagrant-virtualbox-ks.cfg
+++ b/http/centos-6-base-vagrant-virtualbox-ks.cfg
@@ -172,6 +172,10 @@ tuned
 # Remove contents of temporary dictories and zero out free space on disk
 /bin/rm -rf /{root,tmp,var/cache/{ldconfig,yum}}/*
 
+# Remove desktop wallpapers and backgrounds
+find /usr/share/{backgrounds,kde4,wallpapers} \
+  -type f -regextype posix-extended -regex '.*\.(jpg|png)$' -delete
+
 # ------------------------------------------------------------------------------
 # Zero out any remaining free disk space
 # ------------------------------------------------------------------------------

--- a/http/centos-6-base-vagrant-virtualbox-ks.cfg
+++ b/http/centos-6-base-vagrant-virtualbox-ks.cfg
@@ -97,7 +97,6 @@ tuned
 /sbin/dracut -f -H
 /usr/bin/tuned-adm profile virtual-guest
 /usr/bin/yum clean all
-/bin/rpm --erase --nodeps redhat-logos
 /bin/rpm --rebuilddb
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
Resolves #15 
- Don't erase the redhat-logos package - Doing so results in yum errors later.
- Desktop wallpapers and backgrounds are not necessary for headless servers so removed image files instead of the package. 
