### PR TITLE
Release changes for 6.8.2

### DIFF
--- a/centos-6.json
+++ b/centos-6.json
@@ -75,7 +75,9 @@
     {
       "type": "shell",
       "inline": [
-        "/usr/bin/sudo /bin/sed -i -e 's~^PasswordAuthentication yes~PasswordAuthentication no~g' /etc/ssh/sshd_config"
+        "/usr/bin/sudo /bin/sed -i -e 's~^PasswordAuthentication yes~PasswordAuthentication no~g' /etc/ssh/sshd_config",
+        "/usr/bin/sudo /bin/find /var/log -type f | /usr/bin/xargs -I {} /usr/bin/sudo /usr/bin/truncate -s 0 {}",
+        "/usr/bin/sudo /bin/bash -c '/bin/dd if=/dev/zero of=/zero.out bs=1M; /bin/sync; /bin/rm -f /zero.out'"
       ]
     }
   ]

--- a/http/centos-6-base-vagrant-virtualbox-ks.cfg
+++ b/http/centos-6-base-vagrant-virtualbox-ks.cfg
@@ -99,6 +99,10 @@ tuned
 /bin/rpm --erase --nodeps redhat-logos
 /bin/rpm --rebuilddb
 
+# ------------------------------------------------------------------------------
+# Reduce Locale resources
+# ------------------------------------------------------------------------------
+
 # Remove all but en_GB.utf8 and en_US.utf8 from the locale archive and rebuild.
 /usr/bin/localedef --list-archive | \
   /bin/awk '!/^en_(GB|US).utf8$/' | \
@@ -115,6 +119,7 @@ tuned
 
 # Delete all except UTF-8.gz from character map files
 # /bin/find /usr/share/i18n/charmaps -type f -not -name UTF-8.gz -delete
+
 # Remove locale files for unused languages.
 /bin/find /usr/share/i18n/locales -type f | \
   /bin/awk '!/\/en(_(GB|US))?(.(utf|UTF-)8)?$/' | \
@@ -124,11 +129,52 @@ tuned
 # Uncomment to unset system locale
 # /usr/bin/truncate -s 0 /etc/sysconfig/i18n
 
+# ------------------------------------------------------------------------------
+# Seal the machine - Ref: Virtual Machine Management Guide
+# ------------------------------------------------------------------------------
+
+# Flag the system for re-configuration
+# /bin/touch /.unconfigured
+
+# Remove ssh host keys
+/bin/rm -rf /etc/ssh/ssh_host_*
+
+# Set generic HOSTNAME
+/bin/sed -i \
+  -e 's~^HOSTNAME=\(.*\)$~HOSTNAME=localhost.localdomain~g' \
+  /etc/sysconfig/network
+
+# Remove /etc/udev/rules.d/70-*
+/bin/rm -rf /etc/udev/rules.d/70-*
+
+# Remove the HWADDR line and UUID line from 
+# /etc/sysconfig/network-scripts/ifcfg-eth*
+/bin/find /etc/sysconfig/network-scripts -type f -name ifcfg-eth* | \
+  /usr/bin/xargs -I {} \
+    /bin/sed -i \
+      -e '/^HWADDR=/d' \
+      -e '/^UUID=/d' \
+      {}
+
+# ------------------------------------------------------------------------------
+# Optional disk cleanup
+# ------------------------------------------------------------------------------
+
+# Delete all the logs from /var/log
+/bin/find /var/log -type f | \
+  /usr/bin/xargs -I {} \
+    /usr/bin/truncate \
+      -s 0 {}
+
 # Remove manual and documentation files but leave directory structure.
 /bin/find /usr/share/{man,doc,info,gnome/help} -type f -delete
 
 # Remove contents of temporary dictories and zero out free space on disk
 /bin/rm -rf /{root,tmp,var/cache/{ldconfig,yum}}/*
+
+# ------------------------------------------------------------------------------
+# Zero out any remaining free disk space
+# ------------------------------------------------------------------------------
 /bin/dd if=/dev/zero of=/boot/zero.out bs=1M
 /bin/dd if=/dev/zero of=/zero.out bs=1M
 /bin/sync

--- a/http/centos-6-base-vagrant-virtualbox-ks.cfg
+++ b/http/centos-6-base-vagrant-virtualbox-ks.cfg
@@ -13,11 +13,19 @@ authconfig --enableshadow --passalgo=sha512
 selinux --permissive
 zerombr
 bootloader --location=mbr --append="crashkernel=auto rhgb quiet"
+
+# Partitions
 clearpart --all --initlabel
-# part / --grow --size=40960 --fstype=ext4 --asprimary
-# part /boot --size=250 --fstype=ext4
-# part swap --grow --size=1024
-autopart
+part biosboot --size=1 --fstype=biosboot
+part /boot --size=250 --fstype=ext4
+part pv.01 --size=1 --grow
+
+# Logical Volumes
+# 32768 Physical Extents = 16MiB @ 512 bytes/sector.
+volgroup vg_root --pesize=32768 pv.01
+logvol swap --vgname=vg_root --size=768 --name=lv_swap --fstype=swap --grow --maxsize=4096 
+logvol / --vgname=vg_root --size=1024 --name=lv_root --fstype=ext4 --grow
+
 user --name=vagrant --groups=wheel --password=vagrant
 services --enabled ntpd, tuned
 reboot

--- a/http/centos-6-base-vagrant-virtualbox-ks.cfg
+++ b/http/centos-6-base-vagrant-virtualbox-ks.cfg
@@ -19,11 +19,12 @@ clearpart --all --initlabel
 # part swap --grow --size=1024
 autopart
 user --name=vagrant --groups=wheel --password=vagrant
-services --enabled ntpd
+services --enabled ntpd, tuned
 reboot
 
 %packages --instLangs=en_GB.UTF-8 --nobase --nocore --ignoremissing --excludedocs
 @core --nodefaults
+tuned
 
 # Core Mandatory Packages to exclude
 # -cronie
@@ -79,9 +80,10 @@ reboot
 /bin/chown -R vagrant:vagrant /home/vagrant
 /bin/chmod 0600 /home/vagrant/.ssh/authorized_keys
 /sbin/dracut -f -H
+/usr/bin/tuned-adm profile virtual-guest
 /usr/bin/yum clean all
-/bin/rpm --rebuilddb
 /bin/rpm --erase --nodeps redhat-logos
+/bin/rpm --rebuilddb
 /bin/rm -rf /etc/ld.so.cache
 /bin/rm -rf /sbin/sln
 /bin/rm -rf /usr/{{lib,share}/locale,share/{man,doc,info,gnome/help,cracklib,il8n},{lib,lib64}/gconv,bin/localedef,sbin/build-locale-archive}

--- a/http/centos-6-base-vagrant-virtualbox-ks.cfg
+++ b/http/centos-6-base-vagrant-virtualbox-ks.cfg
@@ -172,6 +172,10 @@ tuned
 # Remove contents of temporary dictories and zero out free space on disk
 /bin/rm -rf /{root,tmp,var/cache/{ldconfig,yum}}/*
 
+# Remove desktop wallpapers and backgrounds
+find /usr/share/{backgrounds,kde4,wallpapers} \
+  -type f -regextype posix-extended -regex '.*\.(jpg|png)$' -delete
+
 # ------------------------------------------------------------------------------
 # Zero out any remaining free disk space
 # ------------------------------------------------------------------------------

--- a/http/centos-6-base-vagrant-virtualbox-ks.cfg
+++ b/http/centos-6-base-vagrant-virtualbox-ks.cfg
@@ -97,7 +97,6 @@ tuned
 /sbin/dracut -f -H
 /usr/bin/tuned-adm profile virtual-guest
 /usr/bin/yum clean all
-/bin/rpm --erase --nodeps redhat-logos
 /bin/rpm --rebuilddb
 
 # ------------------------------------------------------------------------------

--- a/http/centos-6-base-vagrant-virtualbox-ks.cfg
+++ b/http/centos-6-base-vagrant-virtualbox-ks.cfg
@@ -32,6 +32,7 @@ reboot
 
 %packages --instLangs=en_GB.UTF-8 --nobase --nocore --ignoremissing --excludedocs
 @core --nodefaults
+nfs-utils
 tuned
 
 # Core Mandatory Packages to exclude

--- a/http/centos-6-base-vagrant-virtualbox-ks.cfg
+++ b/http/centos-6-base-vagrant-virtualbox-ks.cfg
@@ -80,7 +80,13 @@ tuned
 %end
 
 %post
-/bin/sed -i -e 's~^#PermitRootLogin yes~PermitRootLogin no~g' -e 's~^#UseDNS yes~UseDNS no~g' /etc/ssh/sshd_config
+# Prevent SSH root login, prevent DNS lookup of connecting hosts (slow), 
+# Don't allow Locale environment variables - have restricted to en_GB.UTF-8
+/bin/sed -i \
+  -e 's~^#PermitRootLogin yes~PermitRootLogin no~g' \
+  -e 's~^#UseDNS yes~UseDNS no~g' \
+  -e 's~^AcceptEnv \(.*\)~#AcceptEnv \1~g' \
+  /etc/ssh/sshd_config
 /bin/echo -e '%wheel ALL=(ALL) NOPASSWD: ALL' > /etc/sudoers.d/wheel
 /bin/chmod 0440 /etc/sudoers.d/wheel
 /bin/mkdir -pm 0700 /home/vagrant/.ssh
@@ -92,11 +98,37 @@ tuned
 /usr/bin/yum clean all
 /bin/rpm --erase --nodeps redhat-logos
 /bin/rpm --rebuilddb
-/bin/rm -rf /etc/ld.so.cache
-/bin/rm -rf /sbin/sln
-/bin/rm -rf /usr/{{lib,share}/locale,share/{man,doc,info,gnome/help,cracklib,il8n},{lib,lib64}/gconv,bin/localedef,sbin/build-locale-archive}
+
+# Remove all but en_GB.utf8 and en_US.utf8 from the locale archive and rebuild.
+/usr/bin/localedef --list-archive | \
+  /bin/awk '!/^en_(GB|US).utf8$/' | \
+  /usr/bin/xargs /usr/bin/localedef --delete-from-archive
+/bin/mv /usr/lib/locale/locale-archive /usr/lib/locale/locale-archive.tmpl
+/usr/sbin/build-locale-archive
+/usr/bin/truncate -s 0 /usr/lib/locale/locale-archive.tmpl
+
+# Remove all files from subdirectories of /usr/share/locale except the contents  
+# of /usr/share/locale/en_GB or /usr/share/locale/en_@* directories.
+/bin/find /usr/share/locale -mindepth 1 -maxdepth 1 -type d | \
+  /bin/awk '!/^\/usr\/share\/locale\/en(_(GB|US)|@.*)?$/' | \
+  /usr/bin/xargs -I {} /bin/find {} -type f -delete
+
+# Delete all except UTF-8.gz from character map files
+# /bin/find /usr/share/i18n/charmaps -type f -not -name UTF-8.gz -delete
+# Remove locale files for unused languages.
+/bin/find /usr/share/i18n/locales -type f | \
+  /bin/awk '!/\/en(_(GB|US))?(.(utf|UTF-)8)?$/' | \
+  /bin/awk '/[a-z][a-z]([a-z])?_[A-Z][A-Z](@.+)?/' \
+  /usr/bin/xargs -I {} /bin/find {} -type f -delete
+
+# Uncomment to unset system locale
+# /usr/bin/truncate -s 0 /etc/sysconfig/i18n
+
+# Remove manual and documentation files but leave directory structure.
+/bin/find /usr/share/{man,doc,info,gnome/help} -type f -delete
+
+# Remove contents of temporary dictories and zero out free space on disk
 /bin/rm -rf /{root,tmp,var/cache/{ldconfig,yum}}/*
-/bin/echo '' > /etc/sysconfig/i18n
 /bin/dd if=/dev/zero of=/boot/zero.out bs=1M
 /bin/dd if=/dev/zero of=/zero.out bs=1M
 /bin/sync

--- a/http/centos-6-base-vagrant-virtualbox-ks.cfg
+++ b/http/centos-6-base-vagrant-virtualbox-ks.cfg
@@ -23,7 +23,7 @@ part pv.01 --size=1 --grow
 # Logical Volumes
 # 32768 Physical Extents = 16MiB @ 512 bytes/sector.
 volgroup vg_root --pesize=32768 pv.01
-logvol swap --vgname=vg_root --size=768 --name=lv_swap --fstype=swap --grow --maxsize=4096 
+logvol swap --vgname=vg_root --size=512 --name=lv_swap --fstype=swap --grow --maxsize=4096
 logvol / --vgname=vg_root --size=1024 --name=lv_root --fstype=ext4 --grow
 
 user --name=vagrant --groups=wheel --password=vagrant

--- a/http/centos-6-base-vagrant-virtualbox-ks.cfg
+++ b/http/centos-6-base-vagrant-virtualbox-ks.cfg
@@ -19,6 +19,7 @@ clearpart --all --initlabel
 # part swap --grow --size=1024
 autopart
 user --name=vagrant --groups=wheel --password=vagrant
+services --enabled ntpd
 reboot
 
 %packages --instLangs=en_GB.UTF-8 --nobase --nocore --ignoremissing --excludedocs


### PR DESCRIPTION
- Enable ntpd service.
- Install and enable tuned and the virtual-guest profile.
- Manually define partitions and logical volumes.
- Remove unused locales instead of removing all locale support.
- Added steps to 'seal' the guest vm ready for template.
- Added cleanup steps to be run after provisioner scripts.
- Added the nfs-utils package.
- No longer erase the redhat-logos package.
- Remove desktop wallpapers and backgrounds installed by the redhat-logos package.
