### PR TITLE
CLOSES #19: Update example Vagrantfile to use the latest release version.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,7 +1,7 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
-$box_version = "6.8.1"
+$box_version = "6.8.2"
 $share_home = false
 $vm_cpus = 1
 $vm_gui = false


### PR DESCRIPTION
- Updating the version number should be a pre-release process step but got missed out during release of 6.8.2
