### PR TITLE
CLOSES #22: Fixed installation of tuned.

### DIFF
--- a/http/centos-6-base-vagrant-virtualbox-ks.cfg
+++ b/http/centos-6-base-vagrant-virtualbox-ks.cfg
@@ -7,11 +7,11 @@ cdrom
 # url --url http://mirror.centos.org/centos/6.8/os/x86_64
 
 # Add repositories for any packages not available in the Minimal ISO
-repo --name="base" --baseurl=http://mirror.centos.org/centos/6.8/os/x86_64 --cost=100
+repo --name=base --baseurl=http://mirror.centos.org/centos/6.8/os/x86_64 --cost=100
 
 lang en_GB.UTF-8
 keyboard uk
-timezone --utc Etc/UTC
+timezone Etc/UTC --utc
 
 # rootpw --iscrypted $6$Xefaowoo8aiteexu$rzNvFI5shwPoRJeB7IQKIGrMvy3KgzoCttrU/vwUwIMk4rl2Kf7awNnilUJlFYJ2b8OIMOcWitoTSrKPNXOH21
 rootpw vagrant
@@ -19,7 +19,7 @@ rootpw vagrant
 authconfig --enableshadow --passalgo=sha512
 bootloader --location=mbr --append="crashkernel=auto rhgb quiet"
 firewall --enabled --service=ssh
-network --onboot yes --device eth0 --bootproto dhcp --noipv6 --hostname centos-6
+network --onboot=yes --device=eth0 --bootproto=dhcp --noipv6 --hostname=centos-6
 selinux --permissive
 services --enabled=tuned
 

--- a/http/centos-6-base-vagrant-virtualbox-ks.cfg
+++ b/http/centos-6-base-vagrant-virtualbox-ks.cfg
@@ -1,21 +1,31 @@
 install
-cdrom
 text
 skipx
+
+# Install source should be either cdrom or url
+cdrom
+# url --url http://mirror.centos.org/centos/6.8/os/x86_64
+
+# Add repositories for any packages not available in the Minimal ISO
+repo --name="base" --baseurl=http://mirror.centos.org/centos/6.8/os/x86_64 --cost=100
+
 lang en_GB.UTF-8
 keyboard uk
 timezone --utc Etc/UTC
-network --onboot yes --device eth0 --bootproto dhcp --noipv6 --hostname centos-6
+
 # rootpw --iscrypted $6$Xefaowoo8aiteexu$rzNvFI5shwPoRJeB7IQKIGrMvy3KgzoCttrU/vwUwIMk4rl2Kf7awNnilUJlFYJ2b8OIMOcWitoTSrKPNXOH21
 rootpw vagrant
-firewall --enabled --service=ssh
+
 authconfig --enableshadow --passalgo=sha512
-selinux --permissive
-zerombr
 bootloader --location=mbr --append="crashkernel=auto rhgb quiet"
+firewall --enabled --service=ssh
+network --onboot yes --device eth0 --bootproto dhcp --noipv6 --hostname centos-6
+selinux --permissive
+services --enabled=tuned
 
 # Partitions
 clearpart --all --initlabel
+zerombr
 part biosboot --size=1 --fstype=biosboot
 part /boot --size=250 --fstype=ext4
 part pv.01 --size=1 --grow
@@ -27,7 +37,7 @@ logvol swap --vgname=vg_root --size=512 --name=lv_swap --fstype=swap --grow --ma
 logvol / --vgname=vg_root --size=1024 --name=lv_root --fstype=ext4 --grow
 
 user --name=vagrant --groups=wheel --password=vagrant
-services --enabled ntpd, tuned
+
 reboot
 
 %packages --instLangs=en_GB.UTF-8 --nobase --nocore --ignoremissing --excludedocs


### PR DESCRIPTION
- The package `tuned` is not included in the 6.8 Minimal ISO so the  base URL for the base repository is required in the Kickstart configuration.
- Fixed syntax error in `service` Kickstart option; no spaces are allowed between packages.
