### PR TITLE
CLOSES #30: Added all US and GB locales to the localedef archive.

### DIFF
--- a/http/centos-6-base-vagrant-virtualbox-ks.cfg
+++ b/http/centos-6-base-vagrant-virtualbox-ks.cfg
@@ -112,7 +112,7 @@ tuned
 
 # Remove all but en_GB and en_US from the locale archive and rebuild.
 /usr/bin/localedef --list-archive | \
-  /bin/awk '!/^en_(GB|US)(.utf8)?$/' | \
+  /bin/awk '!/^en_(GB|US)(.iso88591|.utf8)?$/' | \
   /usr/bin/xargs /usr/bin/localedef --delete-from-archive
 /bin/mv /usr/lib/locale/locale-archive /usr/lib/locale/locale-archive.tmpl
 /usr/sbin/build-locale-archive

--- a/http/centos-6-base-vagrant-virtualbox-ks.cfg
+++ b/http/centos-6-base-vagrant-virtualbox-ks.cfg
@@ -110,9 +110,9 @@ tuned
 # Reduce Locale resources
 # ------------------------------------------------------------------------------
 
-# Remove all but en_GB.utf8 and en_US.utf8 from the locale archive and rebuild.
+# Remove all but en_GB and en_US from the locale archive and rebuild.
 /usr/bin/localedef --list-archive | \
-  /bin/awk '!/^en_(GB|US).utf8$/' | \
+  /bin/awk '!/^en_(GB|US)(.utf8)?$/' | \
   /usr/bin/xargs /usr/bin/localedef --delete-from-archive
 /bin/mv /usr/lib/locale/locale-archive /usr/lib/locale/locale-archive.tmpl
 /usr/sbin/build-locale-archive


### PR DESCRIPTION
- Added support for en_US and en_GB including the ISO-88591 and UTF-8 variants.
- Fixed startup errors in auditd due to it using a fixed default locale instead of using the system default.
