### PR TITLE
CLOSES #48: Simplify Kickstart and install tuned via Packer's provisioner.

### DIFF
--- a/centos-6.json
+++ b/centos-6.json
@@ -132,6 +132,12 @@
       "remote_folder": "/var/tmp",
       "skip_clean": false,
       "inline": [
+        "/bin/echo '--> Installing packages.'",
+        "/usr/bin/yum -y install \\",
+        "  tuned",
+        "/sbin/chkconfig tuned on",
+        "/usr/bin/tuned-adm profile \\",
+        "  virtual-guest",
         "/bin/echo '--> Configuring SSH.'",
         "/bin/sed -i \\",
         "  -e 's~^PasswordAuthentication yes~PasswordAuthentication no~g' \\",

--- a/http/centos-6-base-vagrant-virtualbox-ks.cfg
+++ b/http/centos-6-base-vagrant-virtualbox-ks.cfg
@@ -1,13 +1,7 @@
 install
 text
 skipx
-
-# Install source should be either cdrom or url
 cdrom
-# url --url http://mirror.centos.org/centos/6.8/os/x86_64
-
-# Add repositories for any packages not available in the Minimal ISO
-repo --name=base --baseurl=http://mirror.centos.org/centos/6.8/os/x86_64 --cost=100
 
 lang en_GB.UTF-8
 keyboard uk
@@ -20,7 +14,6 @@ bootloader --location=mbr
 firewall --enabled --service=ssh
 network --onboot=yes --device=eth0 --bootproto=dhcp --noipv6 --hostname=localhost.localdomain
 selinux --permissive
-services --enabled=tuned
 
 # Partitions
 clearpart --all --initlabel
@@ -39,7 +32,6 @@ reboot
 %packages --instLangs=en_GB.UTF-8 --nobase --nocore --ignoremissing --excludedocs
 @core --nodefaults
 nfs-utils
-tuned
 
 # Core Default Packages to exclude
 -aic94xx-firmware
@@ -80,8 +72,6 @@ tuned
 %post
 # Reduce the size of the initramfs image
 /sbin/dracut -f -H
-
-/usr/bin/tuned-adm profile virtual-guest
 
 # ------------------------------------------------------------------------------
 # Reduce Locale resources


### PR DESCRIPTION
- Install and configure `tuned` via the Packer provisioner. This makes the Kickstart file more generic so it should work with other 6.x releases without changes.
