### PR TITLE
CLOSES #71: Disables cloud-init module cc_locale.

### DIFF
--- a/CentOS-6-minimal-cloud-init-virtualbox.json
+++ b/CentOS-6-minimal-cloud-init-virtualbox.json
@@ -182,6 +182,7 @@
       "scripts": [
         "scripts/install/tuned-virtual-guest.sh",
         "scripts/install/cloud-init.sh",
+        "scripts/cloud-init/disable-locale-module.sh",
         "scripts/common/sshd-config-non-root-key-auth.sh",
         "scripts/common/sudoers-default-not-requiretty.sh",
         "scripts/common/ssh-user.sh",

--- a/scripts/cloud-init/disable-locale-module.sh
+++ b/scripts/cloud-init/disable-locale-module.sh
@@ -1,0 +1,6 @@
+#!/bin/bash -e
+
+/bin/echo '--> Disabling cloud-init locale module.'
+/bin/sed -i \
+  -e 's~^\([ ]*\)\(- locale\)$~\1#\2~' \
+  /etc/cloud/cloud.cfg


### PR DESCRIPTION
Resolves #71 
- Disables cloud-init module cc_locale which cannot be used with locale specific builds.
